### PR TITLE
Bugfix nth Check removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint ."
   },
   "resolutions": {
-    "nth-check": "^2.0.1",
     "ansi-regex": "^5.0.1",
     "nanoid": "^3.1.31",
     "follow-redirects": "^1.14.7",
@@ -29,7 +28,6 @@
     "@react-navigation/stack": "^6.0.11",
     "follow-redirects": "^1.14.7",
     "nanoid": "^3.1.31",
-    "nth-check": "^2.0.1",
     "radio-buttons-react-native": "^1.0.4",
     "react": "17.0.2",
     "react-native": "^0.66.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5853,7 +5853,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@^2.0.1:
+nth-check@^2.0.1, nth-check@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==


### PR DESCRIPTION
<!-- Use this form to create a pull request section that are not required can be removed, or left blank -->

## Pull Request

<!-- If associated with an Issue place the issue number in here
Use the following keywords followed by the issue number:
close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->
<!-- closes #109 -->

**Closes**

### Changes and Updates

- removed nth check from package.json 
- removed yarn

### Added APIs, Webpack or Yarn/NPM installs

<!-- Place within this block anything that is required to get this PR working on another machine -->

- nth-check removed

### Notes

<!-- Any additional notes should be place here -->

- An error was occuring when yarn ios was run stating nth-check was not installed correctly. I belive 
that this is due to an update in nth-check and the version is no longer compatable. If this causes an 
issue nth-check should be re-installed.

